### PR TITLE
Add GitHub token support in PR API calls

### DIFF
--- a/odoo_tools/utils/pending_merge.py
+++ b/odoo_tools/utils/pending_merge.py
@@ -244,9 +244,13 @@ class Repo:
             )
             return True
 
-        response = requests.get(f"{self.api_url(upstream=upstream)}/pulls/{pull_id}")
+        token = os.environ.get("GITHUB_TOKEN")
+        headers = {"Authorization": f"token {token}"} if token else None
+        response = requests.get(
+            f"{self.api_url(upstream=upstream)}/pulls/{pull_id}",
+            headers=headers,
+        )
 
-        # TODO: auth
         base_branch = response.json().get("base", {}).get("ref")
         if response.ok:
             if base_branch:


### PR DESCRIPTION
## Summary
- include `GITHUB_TOKEN` when calling GitHub pull request API
- test that Authorization header is sent when token is set
- test absence of header when no token is configured

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862825a0c38833099ff5a92478d7edb